### PR TITLE
refactor: enum type에서 union type으로 일괄 변경

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Theme } from 'src/types/theme';
+import { ThemeType } from 'src/types/theme';
 import styles from './styles.module.scss';
 import { Loading } from '../loading';
 
@@ -7,7 +7,7 @@ interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   type?: 'button' | 'submit' | 'reset';
   size?: 'small' | 'medium' | 'large';
   full?: boolean;
-  theme?: Theme | string;
+  theme?: ThemeType | string;
   loading?: boolean;
   className?: string;
 }

--- a/src/components/button/IconButton.tsx
+++ b/src/components/button/IconButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Theme } from 'src/types/theme';
+import { ThemeType } from 'src/types/theme';
 import styles from './styles.module.scss';
 import { Loading } from '../loading';
 
@@ -21,7 +21,7 @@ interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   type?: 'button' | 'submit' | 'reset';
   size?: 'small' | 'medium' | 'large';
   full?: boolean;
-  theme?: Theme | string;
+  theme?: ThemeType | string;
   loading?: boolean;
   className?: string;
   prevIcon?: React.ComponentType;

--- a/src/components/capsule-box/MakingCapsuleBox.tsx
+++ b/src/components/capsule-box/MakingCapsuleBox.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { IconCapsuleBoxOpen } from 'src/assets/icons';
 import { themeColor } from 'src/utils/styles';
-import { Theme } from 'src/types/theme';
+import { ThemeType } from 'src/types/theme';
 import styles from './styles.module.scss';
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
-  theme: Theme;
+  theme: ThemeType;
   openedAt: string | null;
   closedAt: string | null;
 }

--- a/src/sections/home/HomeBottomButtons.tsx
+++ b/src/sections/home/HomeBottomButtons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Theme } from 'src/types/theme';
+import { ThemeType } from 'src/types/theme';
 import { Button } from 'src/components/button';
 import { Link } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
@@ -17,7 +17,7 @@ const getDomain = () => {
 };
 
 interface Props {
-  theme: Theme;
+  theme: ThemeType;
 }
 
 // ----------------------------------------------------------------------

--- a/src/sections/home/HomeCapsuleBox.tsx
+++ b/src/sections/home/HomeCapsuleBox.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Theme } from 'src/types/theme';
+import { ThemeType } from 'src/types/theme';
 import { CapsuleBox } from 'src/components/capsule-box';
 import { ICapsuleBox } from 'src/types/capsule';
 import { formatDate } from 'src/utils/date';
 import styles from './styles.module.scss';
 
 interface Props {
-  theme?: Theme;
+  theme?: ThemeType;
   capsuleBox?: ICapsuleBox;
 }
 

--- a/src/store/capsule/makeCapsuleStore.ts
+++ b/src/store/capsule/makeCapsuleStore.ts
@@ -1,13 +1,13 @@
-import { MakeCapsuleStep } from 'src/types/capsule';
+import { MakeCapsuleStep, MakeCapsuleStepType } from 'src/types';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
 interface State {
-  currentStep: MakeCapsuleStep;
+  currentStep: MakeCapsuleStepType;
   isMakeModalOpen: boolean;
 }
 interface Action {
-  setCurrentStep: (currentStep: MakeCapsuleStep) => void;
+  setCurrentStep: (currentStep: MakeCapsuleStepType) => void;
   setIsMakeModalOpen: (isMakeModalOpen: boolean) => void;
 }
 

--- a/src/types/capsule.ts
+++ b/src/types/capsule.ts
@@ -1,16 +1,20 @@
-import { Theme } from './theme';
+import { ThemeType } from './theme';
+import { Union } from './union';
 
 export interface ICapsuleBox {
   capsuleBoxId?: number;
-  theme: Theme;
+  theme: ThemeType;
   openedAt: string;
   closedAt: string;
   capsules: string[];
 }
 
-export enum MakeCapsuleStep {
-  SelectColor = '캡슐함 색상 고르기',
-  SetClosedDate = '캡슐함 봉인일자 설정',
-  SetOpenedDate = '캡슐함 개봉일자 생성',
-  Confirm = '캡슐함을 만드시겠습니까?',
-}
+// MakeCapsuleStep Type assertion
+export const MakeCapsuleStep = {
+  SelectColor: '캡슐함 색상 고르기',
+  SetClosedDate: '캡슐함 봉인일자 설정',
+  SetOpenedDate: '캡슐함 개봉일자 생성',
+  Confirm: '캡슐함을 만드시겠습니까?',
+} as const;
+
+export type MakeCapsuleStepType = Union<typeof MakeCapsuleStep>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,4 @@
+export * from './auth';
+export * from './theme';
+export * from './union';
+export * from './capsule';

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -1,7 +1,12 @@
-export enum Theme {
-  AQUA = 'AQUA',
-  MAGENTA = 'MAGENTA',
-  PURPLE = 'PURPLE',
-  BROWN = 'BROWN',
-  GREIGE = 'GREIGE',
-}
+import { Union } from './union';
+
+// Theme Type assertion
+export const Theme = {
+  AQUA: 'AQUA',
+  BROWN: 'BROWN',
+  PURPLE: 'PURPLE',
+  GREIGE: 'GREIGE',
+  MAGENTA: 'MAGENTA',
+} as const;
+
+export type ThemeType = Union<typeof Theme>;

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -1,0 +1,4 @@
+/**
+ * enum 대체로 union 타입 사용하기 위한 타입 함수
+ */
+export type Union<T> = T[keyof T];

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -1,10 +1,10 @@
-import { Theme } from 'src/types/theme';
+import { Theme, ThemeType } from 'src/types/theme';
 
 /** rem to pixel */
 export const px = (pixel: number) => `${pixel / 16}rem`;
 
 /** get theme color */
-export const themeColor = (theme?: Theme) => {
+export const themeColor = (theme?: ThemeType) => {
   if (theme === Theme.AQUA) return '#8db6cc';
   if (theme === Theme.BROWN) return '#d6b89c';
   if (theme === Theme.PURPLE) return '#ac96d6';


### PR DESCRIPTION
## 요약
enum 타입 -> 유니온 타입으로 일괄 변경

## 변경 사항
enum type은 트리쉐이킹이 안되므로 번들 파일에 포함됨
-> 번들 사이즈가 커짐
-> 초기 로딩 속도 느려짐

이슈로 enum 타입 지양

## 티켓 링크
